### PR TITLE
fix: move lock intervals to the top

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -12,6 +12,11 @@
 <body>
 
   <div class="container mt-5 w-75">
+    <div class="form-check mb-5">
+      <input class="form-check-input" type="checkbox" value="" id="lockIntervalsCheck">
+      <label class="form-check-label" for="lockIntervalsCheck">Lock intervals</label>
+    </div>
+
     <div class="row mb-3">
       <div class="col-sm-10">
         <input type="range" class="form-range" min="0" max="30" step="1" id="sliderBreathIn">
@@ -37,11 +42,6 @@
       <div class="col-sm-2">
         <input type="number" class="form-control" id="inputBreathHold">
       </div>
-    </div>
-
-    <div class="form-check mb-5">
-      <input class="form-check-input" type="checkbox" value="" id="lockIntervalsCheck">
-      <label class="form-check-label" for="lockIntervalsCheck">Lock intervals</label>
     </div>
 
     <div class="mb-3">


### PR DESCRIPTION
Moving the lock interval checkbox to the top lets the user think and decide to apply the lock before changing any values, which may be more intuitive for new users.